### PR TITLE
feat: モデル定義とAutoMigrateを追加

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/gin-gonic/gin"
+	"github.com/salmon-ai/salmon-ai/internal/model"
 	"github.com/salmon-ai/salmon-ai/pkg/database"
 )
 
@@ -20,6 +21,19 @@ func main() {
 	defer sqlDB.Close()
 
 	log.Println("database connected successfully")
+
+	if err := db.AutoMigrate(
+		&model.User{},
+		&model.Category{},
+		&model.Task{},
+		&model.Reflection{},
+		&model.ReflectionMessage{},
+		&model.Report{},
+	); err != nil {
+		log.Fatalf("failed to migrate database: %v", err)
+	}
+
+	log.Println("database migrated successfully")
 
 	r := gin.Default()
 

--- a/backend/internal/model/base.go
+++ b/backend/internal/model/base.go
@@ -1,0 +1,14 @@
+package model
+
+import "time"
+
+type Base struct {
+	ID uint `gorm:"primarykey"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type BaseReadOnly struct {
+	ID uint `gorm:"primarykey"`
+	CreatedAt time.Time
+}

--- a/backend/internal/model/category.go
+++ b/backend/internal/model/category.go
@@ -1,0 +1,9 @@
+package model
+
+type Category struct {
+	Base
+	UserID uint   `gorm:"index;not null"`
+	User User `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE"`
+	Name   string `gorm:"not null"`
+	Color  string `gorm:"not null"`
+}

--- a/backend/internal/model/reflection.go
+++ b/backend/internal/model/reflection.go
@@ -1,0 +1,11 @@
+package model
+
+import "time"
+
+type Reflection struct {
+	Base
+	UserID  uint      `gorm:"index;not null"`
+	User    User      `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE"`
+	Date    time.Time `gorm:"index;not null"`
+	Content *string
+}

--- a/backend/internal/model/reflection_message.go
+++ b/backend/internal/model/reflection_message.go
@@ -1,0 +1,9 @@
+package model
+
+type ReflectionMessage struct {
+	BaseReadOnly
+	ReflectionID uint       `gorm:"index;not null"`
+	Reflection   Reflection `gorm:"foreignKey:ReflectionID;constraint:OnDelete:CASCADE"`
+	Role         string     `gorm:"not null"`
+	Content      string     `gorm:"not null"`
+}

--- a/backend/internal/model/report.go
+++ b/backend/internal/model/report.go
@@ -1,0 +1,8 @@
+package model
+
+type Report struct {
+	BaseReadOnly
+	UserID  uint   `gorm:"index;not null"`
+	User    User   `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE"`
+	Content string `gorm:"not null"`
+}

--- a/backend/internal/model/task.go
+++ b/backend/internal/model/task.go
@@ -1,0 +1,21 @@
+package model
+
+import "time"
+
+type Task struct {
+	Base
+	UserID           uint      `gorm:"index;not null"`
+	User             User      `gorm:"foreignKey:UserID;constraint:OnDelete:CASCADE"`
+	CategoryID       *uint
+	Category         *Category `gorm:"foreignKey:CategoryID;constraint:OnDelete:SET NULL"`
+	Title            string    `gorm:"not null"`
+	Description      *string
+	Priority         *int
+	IsCompleted      bool       `gorm:"not null;default:false"`
+	EstimatedHours   *float64
+	AiEstimatedHours *float64
+	StartTime        *time.Time `gorm:"index"`
+	EndTime          *time.Time
+	DueDate          *time.Time
+	AchievementRate  *int
+}

--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -1,0 +1,8 @@
+package model
+
+type User struct {
+	Base
+	Email string `gorm:"not null"`
+	Name string `gorm:"not null"`
+	UserContext *string
+}


### PR DESCRIPTION
## モデル定義 + AutoMigrate

### 概要
各テーブルのモデル定義とAutoMigrateの設定を追加しました。

### 変更内容
- `internal/model/base.go`: Base・BaseReadOnlyの共通モデルを追加
- `internal/model/user.go`: Userモデルを追加
- `internal/model/category.go`: Categoryモデルを追加（UserへのCASCADE）
- `internal/model/task.go`: Taskモデルを追加（UserへのCASCADE・CategoryへのSET NULL）
- `internal/model/reflection.go`: Reflectionモデルを追加（UserへのCASCADE）
- `internal/model/reflection_message.go`: ReflectionMessageモデルを追加（ReflectionへのCASCADE）
- `internal/model/report.go`: Reportモデルを追加（UserへのCASCADE）
- `cmd/server/main.go`: AutoMigrateの呼び出しを追加

### 動作確認
```bash
cd infra && docker compose up --build
```

以下のログが出ることを確認する。
```
backend-1  | database connected successfully
backend-1  | database migrated successfully
```

DBのテーブルと外部キー制約を確認する。
```bash
docker compose exec postgres psql -U user -d appdb
\dt        # 6テーブルが存在すること
\d tasks   # 外部キー制約・インデックスが作成されていること
```