### PR TITLE
feat: モックユーザーの自動作成を追加

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -35,6 +35,21 @@ func main() {
 
 	log.Println("database migrated successfully")
 
+	// モックユーザーの作成
+	var mockUser model.User
+	result := db.FirstOrCreate(&mockUser, model.User{
+		Email: "mock@example.com",
+		Name: "モックユーザー",
+	})
+	if result.Error != nil {
+		log.Fatalf("failed to create mock user: %v", result.Error)
+	}
+	if result.RowsAffected == 1 {
+		log.Printf("mock user created: id=%d", mockUser.ID)
+	} else {
+		log.Printf("mock user already exists: id=%d", mockUser.ID)
+	}
+
 	r := gin.Default()
 
 	r.GET("/health", func(c *gin.Context) {


### PR DESCRIPTION
## PR

### モックユーザーの自動作成

#### 概要
認証機能の実装を後回しにするため、サーバー起動時にDBへ固定のモックユーザーを自動作成する仕組みを追加しました。

#### 変更内容
- `cmd/server/main.go`: AutoMigrate後にモックユーザーをFirstOrCreateで作成

#### 動作確認

```bash
cd infra && docker compose up --build
```

1回目の起動でユーザーが作成されることを確認する。
```
backend-1  | mock user created: id=1
```

2回目以降の起動で重複作成されないことを確認する。
```
backend-1  | mock user already exists: id=1
```

DBで直接確認する。
```bash
docker compose exec postgres psql -U user -d appdb
SELECT * FROM users;
```