### PR TITLE
feat: Cloud SQLの作成（Terraform）

### DIFF
--- a/infra/terraform/cloud_sql.tf
+++ b/infra/terraform/cloud_sql.tf
@@ -1,0 +1,26 @@
+resource "google_sql_database_instance" "salmon_ai" {
+  name             = "salmon-ai-db"
+  database_version = "POSTGRES_15"
+  region           = var.region
+
+  settings {
+    tier = "db-f1-micro"  # 最小スペック
+
+    backup_configuration {
+      enabled = false  # バックアップ不要
+    }
+  }
+
+  deletion_protection = false  # terraform destroyで削除できるようにする
+}
+
+resource "google_sql_database" "salmon_ai" {
+  name     = "appdb"
+  instance = google_sql_database_instance.salmon_ai.name
+}
+
+resource "google_sql_user" "salmon_ai" {
+  name     = "salmon"
+  instance = google_sql_database_instance.salmon_ai.name
+  password = var.db_password
+}

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -13,3 +13,9 @@ variable "credentials_file" {
   description = "サービスアカウントキーのパス"
   type = string
 }
+
+variable "db_password" {
+  description = "Cloud SQLのパスワード"
+  type        = string
+  sensitive   = true  # ログに表示されないようにする
+}


### PR DESCRIPTION
## コミットメッセージ

```
feat: Cloud SQLの作成（Terraform）
```

---

## PR

### Cloud SQLの作成（Terraform）

#### 概要
PostgreSQLのインスタンスをTerraformで作成しました。

#### 変更内容
- `infra/terraform/cloud_sql.tf`: Cloud SQLインスタンス・データベース・ユーザーを定義
- `infra/terraform/variables.tf`: `db_password` 変数を追加

#### インフラ構成

```
Cloud SQL（asia-northeast1）
└── salmon-ai-db（PostgreSQL 15, db-f1-micro）
    └── appdb
        └── ユーザー: salmon
```

#### セットアップ手順

Cloud SQL APIを有効化します。

```bash
gcloud services enable sqladmin.googleapis.com --project=...
```

`terraform.tfvars` に以下を追加します。

```hcl
db_password = "任意のパスワード"
```

デプロイします。

```bash
cd infra/terraform
terraform apply
```

#### 注意事項

使い終わったら必ず削除してください。

```bash
terraform destroy
```