### PR TITLE
feat: Cloud RunへのBackend・AIサービスのデプロイ（Terraform）

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -189,7 +189,11 @@ func main() {
 	// Schedule（スケジュールサポート）
 	r.POST("/ai/schedule/support", scheduleHandler.ScheduleSupport)
 
-	if err := r.Run(":8080"); err != nil {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	if err := r.Run(":" + port); err != nil {
 		log.Fatalf("failed to start server: %v", err)
 	}
 }

--- a/infra/backend.prod.dockerfile
+++ b/infra/backend.prod.dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.25-bookworm AS builder
+WORKDIR /app
+COPY backend/go.mod backend/go.sum ./
+RUN go mod download
+COPY backend/ .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o server ./cmd/server
+
+FROM debian:bookworm-slim
+WORKDIR /app
+COPY --from=builder /app/server .
+EXPOSE 8080
+CMD ["./server"]

--- a/infra/terraform/cloud_run.tf
+++ b/infra/terraform/cloud_run.tf
@@ -1,0 +1,71 @@
+# Backend
+resource "google_cloud_run_v2_service" "backend" {
+  name     = "salmon-ai-backend"
+  location = var.region
+
+  template {
+    containers {
+      image = "asia-northeast1-docker.pkg.dev/${var.project_id}/salmon-ai/backend:latest"
+
+      env {
+        name  = "DATABASE_URL"
+        value = "postgres://salmon:${var.db_password}@${google_sql_database_instance.salmon_ai.public_ip_address}/appdb"
+      }
+
+      env {
+        name  = "AI_SERVICE_URL"
+        value = "https://${google_cloud_run_v2_service.ai.uri}"
+      }
+
+      ports {
+        container_port = 8080
+      }
+    }
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 1
+    }
+  }
+}
+
+# AIサービス
+resource "google_cloud_run_v2_service" "ai" {
+  name     = "salmon-ai-ai"
+  location = var.region
+
+  template {
+    containers {
+      image = "asia-northeast1-docker.pkg.dev/${var.project_id}/salmon-ai/ai:latest"
+
+      env {
+        name  = "GEMINI_API_KEY"
+        value = var.gemini_api_key
+      }
+
+      ports {
+        container_port = 8000
+      }
+    }
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 1
+    }
+  }
+}
+
+# BackendからのアクセスをCloud Runに許可
+resource "google_cloud_run_v2_service_iam_member" "backend_public" {
+  name     = google_cloud_run_v2_service.backend.name
+  location = var.region
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}
+
+resource "google_cloud_run_v2_service_iam_member" "ai_public" {
+  name     = google_cloud_run_v2_service.ai.name
+  location = var.region
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/infra/terraform/cloud_sql.tf
+++ b/infra/terraform/cloud_sql.tf
@@ -4,14 +4,21 @@ resource "google_sql_database_instance" "salmon_ai" {
   region           = var.region
 
   settings {
-    tier = "db-f1-micro"  # 最小スペック
+    tier = "db-f1-micro"
+    ip_configuration {
+      ipv4_enabled = true
+      authorized_networks {
+        name  = "all"
+        value = "0.0.0.0/0"
+      }
+    }
 
     backup_configuration {
-      enabled = false  # バックアップ不要
+      enabled = false # バックアップ不要
     }
   }
 
-  deletion_protection = false  # terraform destroyで削除できるようにする
+  deletion_protection = false # terraform destroyで削除できるようにする
 }
 
 resource "google_sql_database" "salmon_ai" {

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,21 +1,29 @@
 variable "project_id" {
   description = "Google CloudのプロジェクトID"
-  type = string 
+  type        = string
+  sensitive   = true
 }
 
 variable "region" {
   description = "リージョン"
-  type = string
-  default = "asia-northeast1" # 東京
+  type        = string
+  default     = "asia-northeast1"
 }
 
 variable "credentials_file" {
   description = "サービスアカウントキーのパス"
-  type = string
+  type        = string
+  sensitive   = true
 }
 
 variable "db_password" {
   description = "Cloud SQLのパスワード"
   type        = string
-  sensitive   = true  # ログに表示されないようにする
+  sensitive   = true
+}
+
+variable "gemini_api_key" {
+  description = "Gemini APIキー"
+  type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
## PR

### Cloud RunへのBackend・AIサービスのデプロイ（Terraform）

#### 概要
BackendとAIサービスをCloud RunにTerraformでデプロイしました。

#### 変更内容
- `infra/backend.prod.dockerfile`: 本番用Dockerfileを追加（airなし・バイナリのみ）
- `infra/terraform/cloud_run.tf`: BackendとAIサービスのCloud Runリソースを定義
- `infra/terraform/cloud_sql.tf`: Cloud RunからCloud SQLへの接続を許可（`authorized_networks`）
- `infra/terraform/variables.tf`: `gemini_api_key` を追加・各変数に `sensitive = true` を追加
- `backend/cmd/server/main.go`: `PORT` 環境変数を読み込むよう修正

#### インフラ構成

```
Cloud Run（asia-northeast1）
├── salmon-ai-backend
│   ├── DATABASE_URL → Cloud SQL（salmon-ai-db）
│   └── AI_SERVICE_URL → salmon-ai-ai
└── salmon-ai-ai
    └── GEMINI_API_KEY
```

#### セットアップ手順

Cloud Run APIを有効化します。

```bash
gcloud services enable run.googleapis.com
```

サービスアカウントに権限を付与します。

```bash
gcloud projects add-iam-policy-binding <PROJECT_ID> \
  --member="serviceAccount:terraform-sa@<PROJECT_ID>.iam.gserviceaccount.com" \
  --role="roles/run.admin"
```

本番用イメージをビルドしてプッシュします。

```bash
# Backend
docker build \
  --platform linux/amd64 \
  -t asia-northeast1-docker.pkg.dev/<PROJECT_ID>/salmon-ai/backend:latest \
  -f infra/backend.prod.dockerfile \
  .
docker push asia-northeast1-docker.pkg.dev/<PROJECT_ID>/salmon-ai/backend:latest

# AI
docker build \
  --platform linux/amd64 \
  -t asia-northeast1-docker.pkg.dev/<PROJECT_ID>/salmon-ai/ai:latest \
  -f infra/ai.dockerfile \
  .
docker push asia-northeast1-docker.pkg.dev/<PROJECT_ID>/salmon-ai/ai:latest
```

`terraform.tfvars` に以下を追加します。

```hcl
gemini_api_key = "your-gemini-api-key"
```

デプロイします。

```bash
cd infra/terraform
terraform apply
```

#### 動作確認

```bash
curl https://.../health
# {"status":"ok","userID":1}
```

#### トラブルシューティング

**コンテナが起動しない場合**

Apple Silicon（ARM）でビルドしたイメージはCloud RunのAMD64に対応していないため `--platform linux/amd64` が必要です。

**DB接続がタイムアウトする場合**

Cloud SQLの `authorized_networks` に `0.0.0.0/0` を追加してください。