### PR TITLE
feat:開始/終了時刻入力を追加し、差分から工数を自動設定

### DIFF
--- a/frontend/src/components/task-list/EditTaskModal.tsx
+++ b/frontend/src/components/task-list/EditTaskModal.tsx
@@ -76,9 +76,18 @@ export function DurationInput({
   const [customM, setCustomM] = useState<string>("0");
 
   useEffect(() => {
-    setSelectedMins(initialMins);
-    setCustomH("");
-    setCustomM("0");
+    const isQuick = DURATION_QUICK.some((d) => d.mins === initialMins);
+    if (isQuick || initialMins === null) {
+      setSelectedMins(initialMins);
+      setCustomH("");
+      setCustomM("0");
+    } else {
+      setSelectedMins(null);
+      const h = Math.floor(initialMins / 60);
+      const m = initialMins % 60;
+      setCustomH(String(h));
+      setCustomM(String(m));
+    }
   }, [initialMins]);
 
   const customDurationMins =

--- a/frontend/src/components/task-list/EditTaskModal.tsx
+++ b/frontend/src/components/task-list/EditTaskModal.tsx
@@ -61,6 +61,8 @@ function localDateTimeInputToIso(value: string): string | null {
   return d.toISOString().slice(0, 19) + "Z";
 }
 
+export { isoToLocalDateTimeInput, localDateTimeInputToIso };
+
 // ────────────────────────────────────────────
 // 共通: 見積もり時間入力
 // ────────────────────────────────────────────
@@ -254,7 +256,7 @@ export function DueDateInput({
   return (
     <div>
       <label className="text-[11px] font-semibold text-slate-500 mb-1.5 block">
-        期限（任意）
+        期限
       </label>
       {dueDate && (
         <div className="flex items-baseline justify-center gap-1.5 bg-indigo-50 rounded-xl py-2 mb-2">
@@ -352,7 +354,7 @@ export function CategorySelect({
   return (
     <div>
       <label className="text-[11px] font-semibold text-slate-500 mb-1.5 block">
-        カテゴリ（任意）
+        カテゴリ
       </label>
       <select
         value={value ?? ""}
@@ -540,7 +542,7 @@ export default function EditTaskModal({
           </div>
           <DurationInput initialMins={initMins} onChange={setDurationMins} />
           <div>
-            <label className={labelCls}>開始時間・終了時間（任意）</label>
+            <label className={labelCls}>開始時間・終了時間</label>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
               <input
                 type="datetime-local"

--- a/frontend/src/components/task-list/EditTaskModal.tsx
+++ b/frontend/src/components/task-list/EditTaskModal.tsx
@@ -1,19 +1,19 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Task } from "./types";
 
 export type Category = { id: number; name: string; color: string };
 
 const DURATION_QUICK: { label: string; mins: number }[] = [
-  { label: "15m",  mins: 15  },
-  { label: "30m",  mins: 30  },
-  { label: "45m",  mins: 45  },
-  { label: "1h",   mins: 60  },
-  { label: "1.5h", mins: 90  },
-  { label: "2h",   mins: 120 },
-  { label: "3h",   mins: 180 },
-  { label: "4h",   mins: 240 },
+  { label: "15m", mins: 15 },
+  { label: "30m", mins: 30 },
+  { label: "45m", mins: 45 },
+  { label: "1h", mins: 60 },
+  { label: "1.5h", mins: 90 },
+  { label: "2h", mins: 120 },
+  { label: "3h", mins: 180 },
+  { label: "4h", mins: 240 },
 ];
 
 function fmtMins(mins: number): string {
@@ -25,7 +25,9 @@ function fmtMins(mins: number): string {
 }
 
 function addDays(d: Date, n: number): Date {
-  const r = new Date(d); r.setDate(r.getDate() + n); return r;
+  const r = new Date(d);
+  r.setDate(r.getDate() + n);
+  return r;
 }
 
 function makeDueDate(year: number, month: number, day: number): Date {
@@ -43,6 +45,22 @@ export function toLocalDateStr(d: Date): string {
   return `${y}-${m}-${day}`;
 }
 
+function isoToLocalDateTimeInput(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const offsetMs = d.getTimezoneOffset() * 60 * 1000;
+  const local = new Date(d.getTime() - offsetMs);
+  return local.toISOString().slice(0, 16);
+}
+
+function localDateTimeInputToIso(value: string): string | null {
+  if (!value) return null;
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString().slice(0, 19) + "Z";
+}
+
 // ────────────────────────────────────────────
 // 共通: 見積もり時間入力
 // ────────────────────────────────────────────
@@ -56,6 +74,12 @@ export function DurationInput({
   const [selectedMins, setSelectedMins] = useState<number | null>(initialMins);
   const [customH, setCustomH] = useState<string>("");
   const [customM, setCustomM] = useState<string>("0");
+
+  useEffect(() => {
+    setSelectedMins(initialMins);
+    setCustomH("");
+    setCustomM("0");
+  }, [initialMins]);
 
   const customDurationMins =
     customH !== "" || customM !== "0"
@@ -73,7 +97,8 @@ export function DurationInput({
     setCustomH(h);
     setCustomM(m);
     setSelectedMins(null);
-    const mins = h !== "" || m !== "0" ? parseInt(h || "0") * 60 + parseInt(m) : null;
+    const mins =
+      h !== "" || m !== "0" ? parseInt(h || "0") * 60 + parseInt(m) : null;
     onChange(mins);
   }
   function handleClear() {
@@ -85,7 +110,9 @@ export function DurationInput({
 
   return (
     <div>
-      <label className="text-[11px] font-semibold text-slate-500 mb-1.5 block">見積もり時間</label>
+      <label className="text-[11px] font-semibold text-slate-500 mb-1.5 block">
+        見積もり時間
+      </label>
       {durationMins !== null && (
         <div className="flex items-baseline justify-center gap-1 bg-indigo-50 rounded-xl py-2 mb-2">
           <span className="text-[28px] font-bold text-indigo-600 leading-none tabular-nums">
@@ -128,7 +155,9 @@ export function DurationInput({
           placeholder="0"
           className="w-16 border border-slate-200 rounded-xl px-3 py-2.5 text-[13px] text-slate-800 text-center focus:outline-none focus:ring-2 focus:ring-indigo-300 transition"
         />
-        <span className="text-[13px] text-slate-500 font-medium shrink-0">h</span>
+        <span className="text-[13px] text-slate-500 font-medium shrink-0">
+          h
+        </span>
         <select
           value={customM}
           onChange={(e) => handleCustomDuration(customH, e.target.value)}
@@ -139,7 +168,9 @@ export function DurationInput({
           <option value="30">30</option>
           <option value="45">45</option>
         </select>
-        <span className="text-[13px] text-slate-500 font-medium shrink-0">m</span>
+        <span className="text-[13px] text-slate-500 font-medium shrink-0">
+          m
+        </span>
       </div>
     </div>
   );
@@ -158,16 +189,22 @@ export function DueDateInput({
   const today = new Date();
   const THIS_YEAR = today.getFullYear();
   const DUE_QUICK = [
-    { label: "今日",  date: today             },
-    { label: "明日",  date: addDays(today, 1) },
+    { label: "今日", date: today },
+    { label: "明日", date: addDays(today, 1) },
     { label: "3日後", date: addDays(today, 3) },
-    { label: "来週",  date: addDays(today, 7) },
+    { label: "来週", date: addDays(today, 7) },
   ];
 
   const [dueDate, setDueDate] = useState<Date | null>(initialDate);
-  const [customYear,  setCustomYear]  = useState<string>(String(initialDate?.getFullYear() ?? THIS_YEAR));
-  const [customMonth, setCustomMonth] = useState<string>(initialDate ? String(initialDate.getMonth() + 1) : "");
-  const [customDay,   setCustomDay]   = useState<string>(initialDate ? String(initialDate.getDate()) : "");
+  const [customYear, setCustomYear] = useState<string>(
+    String(initialDate?.getFullYear() ?? THIS_YEAR),
+  );
+  const [customMonth, setCustomMonth] = useState<string>(
+    initialDate ? String(initialDate.getMonth() + 1) : "",
+  );
+  const [customDay, setCustomDay] = useState<string>(
+    initialDate ? String(initialDate.getDate()) : "",
+  );
 
   function handleQuickDue(d: Date) {
     setDueDate(d);
@@ -177,7 +214,9 @@ export function DueDateInput({
     onChange(d);
   }
   function handleCustomDue(year: string, month: string, day: string) {
-    setCustomYear(year); setCustomMonth(month); setCustomDay(day);
+    setCustomYear(year);
+    setCustomMonth(month);
+    setCustomDay(day);
     const y = parseInt(year);
     const m = parseInt(month);
     const d = parseInt(day);
@@ -196,13 +235,18 @@ export function DueDateInput({
     }
   }
   function clearDue() {
-    setDueDate(null); setCustomYear(String(THIS_YEAR)); setCustomMonth(""); setCustomDay("");
+    setDueDate(null);
+    setCustomYear(String(THIS_YEAR));
+    setCustomMonth("");
+    setCustomDay("");
     onChange(null);
   }
 
   return (
     <div>
-      <label className="text-[11px] font-semibold text-slate-500 mb-1.5 block">期限（任意）</label>
+      <label className="text-[11px] font-semibold text-slate-500 mb-1.5 block">
+        期限（任意）
+      </label>
       {dueDate && (
         <div className="flex items-baseline justify-center gap-1.5 bg-indigo-50 rounded-xl py-2 mb-2">
           <span className="text-[28px] font-bold text-indigo-600 leading-none tabular-nums">
@@ -232,7 +276,9 @@ export function DueDateInput({
       <div className="flex items-center gap-1.5">
         <select
           value={customYear}
-          onChange={(e) => handleCustomDue(e.target.value, customMonth, customDay)}
+          onChange={(e) =>
+            handleCustomDue(e.target.value, customMonth, customDay)
+          }
           className="w-24 border border-slate-200 rounded-xl px-2 py-2.5 text-[13px] text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-300 bg-white transition"
         >
           <option value={THIS_YEAR}>{THIS_YEAR}年</option>
@@ -240,22 +286,30 @@ export function DueDateInput({
         </select>
         <select
           value={customMonth}
-          onChange={(e) => handleCustomDue(customYear, e.target.value, customDay)}
+          onChange={(e) =>
+            handleCustomDue(customYear, e.target.value, customDay)
+          }
           className="flex-1 border border-slate-200 rounded-xl px-2 py-2.5 text-[13px] text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-300 bg-white transition"
         >
           <option value="">月</option>
           {Array.from({ length: 12 }, (_, i) => i + 1).map((m) => (
-            <option key={m} value={m}>{m}月</option>
+            <option key={m} value={m}>
+              {m}月
+            </option>
           ))}
         </select>
         <select
           value={customDay}
-          onChange={(e) => handleCustomDue(customYear, customMonth, e.target.value)}
+          onChange={(e) =>
+            handleCustomDue(customYear, customMonth, e.target.value)
+          }
           className="flex-1 border border-slate-200 rounded-xl px-2 py-2.5 text-[13px] text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-300 bg-white transition"
         >
           <option value="">日</option>
           {Array.from({ length: 31 }, (_, i) => i + 1).map((d) => (
-            <option key={d} value={d}>{d}日</option>
+            <option key={d} value={d}>
+              {d}日
+            </option>
           ))}
         </select>
         {dueDate && (
@@ -284,18 +338,25 @@ export function CategorySelect({
   value: number | null;
   onChange: (id: number | null) => void;
 }) {
-  const inputCls = "w-full border border-slate-200 rounded-xl px-3.5 py-2.5 text-[13px] text-slate-800 placeholder-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-300 transition";
+  const inputCls =
+    "w-full border border-slate-200 rounded-xl px-3.5 py-2.5 text-[13px] text-slate-800 placeholder-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-300 transition";
   return (
     <div>
-      <label className="text-[11px] font-semibold text-slate-500 mb-1.5 block">カテゴリ（任意）</label>
+      <label className="text-[11px] font-semibold text-slate-500 mb-1.5 block">
+        カテゴリ（任意）
+      </label>
       <select
         value={value ?? ""}
-        onChange={(e) => onChange(e.target.value ? parseInt(e.target.value) : null)}
+        onChange={(e) =>
+          onChange(e.target.value ? parseInt(e.target.value) : null)
+        }
         className={`${inputCls} bg-white`}
       >
         <option value="">なし</option>
         {categories.map((c) => (
-          <option key={c.id} value={c.id}>{c.name}</option>
+          <option key={c.id} value={c.id}>
+            {c.name}
+          </option>
         ))}
       </select>
     </div>
@@ -306,7 +367,11 @@ export function CategorySelect({
 // タスク編集モーダル
 // ────────────────────────────────────────────
 export default function EditTaskModal({
-  task, onClose, onUpdate, onDelete, categories,
+  task,
+  onClose,
+  onUpdate,
+  onDelete,
+  categories,
 }: {
   task: Task;
   onClose: () => void;
@@ -316,47 +381,148 @@ export default function EditTaskModal({
 }) {
   const [title, setTitle] = useState(task.title);
   const [description, setDescription] = useState(task.description ?? "");
-  const [priority, setPriority] = useState(task.priority != null ? String(task.priority) : "");
-  const [categoryId, setCategoryId] = useState<number | null>(task.category?.id ?? null);
+  const [priority, setPriority] = useState(
+    task.priority != null ? String(task.priority) : "",
+  );
+  const [categoryId, setCategoryId] = useState<number | null>(
+    task.category?.id ?? null,
+  );
 
-  const initMins = task.estimated_hours != null ? Math.round(task.estimated_hours * 60) : null;
+  const initMins =
+    task.estimated_hours != null ? Math.round(task.estimated_hours * 60) : null;
   const [durationMins, setDurationMins] = useState<number | null>(initMins);
 
   const initDue = task.due_date ? new Date(task.due_date) : null;
   const [dueDate, setDueDate] = useState<Date | null>(initDue);
+  const [startAt, setStartAt] = useState<string>(
+    isoToLocalDateTimeInput(task.start_time),
+  );
+  const [endAt, setEndAt] = useState<string>(
+    isoToLocalDateTimeInput(task.end_time),
+  );
+  const [timeError, setTimeError] = useState<string | null>(null);
+
+  function applyDurationFromRange(nextStart: string, nextEnd: string) {
+    if (!nextStart || !nextEnd) return;
+    const start = new Date(nextStart);
+    const end = new Date(nextEnd);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return;
+    const diffMins = Math.round((end.getTime() - start.getTime()) / 60000);
+    if (diffMins > 0) {
+      setDurationMins(diffMins);
+    }
+  }
+
+  function handleChangeStart(next: string) {
+    setStartAt(next);
+    setTimeError(null);
+    applyDurationFromRange(next, endAt);
+  }
+
+  function handleChangeEnd(next: string) {
+    setEndAt(next);
+    setTimeError(null);
+    applyDurationFromRange(startAt, next);
+  }
+
+  function clearRange() {
+    setStartAt("");
+    setEndAt("");
+    setTimeError(null);
+  }
 
   function handleSave() {
     if (!title.trim()) return;
-    onUpdate({ ...task, title: title.trim(), description: description.trim() || null, priority: priority !== "" ? parseInt(priority) as 1 | 2 | 3 : null, estimated_hours: durationMins != null ? durationMins / 60 : null, due_date: dueDate ? toLocalDateStr(dueDate) : null }, categoryId);
+    if ((startAt && !endAt) || (!startAt && endAt)) {
+      setTimeError("開始時間と終了時間はセットで入力してください");
+      return;
+    }
+
+    if (startAt && endAt) {
+      const start = new Date(startAt);
+      const end = new Date(endAt);
+      if (end.getTime() <= start.getTime()) {
+        setTimeError("終了時間は開始時間より後にしてください");
+        return;
+      }
+    }
+
+    const startIso = localDateTimeInputToIso(startAt);
+    const endIso = localDateTimeInputToIso(endAt);
+    const computedHours =
+      startAt && endAt
+        ? (new Date(endAt).getTime() - new Date(startAt).getTime()) / 3600000
+        : durationMins != null
+          ? durationMins / 60
+          : null;
+
+    onUpdate(
+      {
+        ...task,
+        title: title.trim(),
+        description: description.trim() || null,
+        priority: priority !== "" ? (parseInt(priority) as 1 | 2 | 3) : null,
+        estimated_hours: computedHours,
+        due_date: dueDate ? toLocalDateStr(dueDate) : null,
+        start_time: startIso,
+        end_time: endIso,
+      },
+      categoryId,
+    );
     onClose();
   }
 
-  const inputCls = "w-full border border-slate-200 rounded-xl px-3.5 py-2.5 text-[13px] text-slate-800 placeholder-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-300 transition";
+  const inputCls =
+    "w-full border border-slate-200 rounded-xl px-3.5 py-2.5 text-[13px] text-slate-800 placeholder-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-300 transition";
   const labelCls = "text-[11px] font-semibold text-slate-500 mb-1.5 block";
 
   return (
     <div className="fixed inset-0 z-[80] flex items-end sm:items-center justify-center pb-16 sm:pb-0 sm:p-4">
-      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={onClose}
+      />
       <div className="relative bg-white w-full sm:max-w-md rounded-t-3xl sm:rounded-2xl shadow-2xl p-6 max-h-[90svh] overflow-y-auto">
         <div className="w-8 h-1 rounded-full bg-slate-200 mx-auto mb-5 sm:hidden" />
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-[16px] font-bold text-slate-900">タスクを編集</h2>
-          <button onClick={() => onDelete(task.id)} className="w-9 h-9 rounded-xl flex items-center justify-center text-slate-400 hover:text-red-500 hover:bg-red-50 transition-colors" aria-label="タスクを削除">
+          <button
+            onClick={() => onDelete(task.id)}
+            className="w-9 h-9 rounded-xl flex items-center justify-center text-slate-400 hover:text-red-500 hover:bg-red-50 transition-colors"
+            aria-label="タスクを削除"
+          >
             🗑
           </button>
         </div>
         <div className="flex flex-col gap-4">
           <div>
-            <label className={labelCls}>タスク名 <span className="text-red-400">*</span></label>
-            <input type="text" autoFocus value={title} onChange={(e) => setTitle(e.target.value)} className={inputCls} />
+            <label className={labelCls}>
+              タスク名 <span className="text-red-400">*</span>
+            </label>
+            <input
+              type="text"
+              autoFocus
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className={inputCls}
+            />
           </div>
           <div>
             <label className={labelCls}>詳細（任意）</label>
-            <textarea rows={2} value={description} onChange={(e) => setDescription(e.target.value)} className={`${inputCls} resize-none`} />
+            <textarea
+              rows={2}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className={`${inputCls} resize-none`}
+            />
           </div>
           <div>
             <label className={labelCls}>優先度</label>
-            <select value={priority} onChange={(e) => setPriority(e.target.value)} className={`${inputCls} bg-white`}>
+            <select
+              value={priority}
+              onChange={(e) => setPriority(e.target.value)}
+              className={`${inputCls} bg-white`}
+            >
               <option value="">未設定</option>
               <option value="1">高</option>
               <option value="2">中</option>
@@ -364,12 +530,61 @@ export default function EditTaskModal({
             </select>
           </div>
           <DurationInput initialMins={initMins} onChange={setDurationMins} />
+          <div>
+            <label className={labelCls}>開始時間・終了時間（任意）</label>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <input
+                type="datetime-local"
+                value={startAt}
+                onChange={(e) => handleChangeStart(e.target.value)}
+                className={inputCls}
+              />
+              <input
+                type="datetime-local"
+                value={endAt}
+                onChange={(e) => handleChangeEnd(e.target.value)}
+                className={inputCls}
+              />
+            </div>
+            <div className="flex items-center justify-between mt-1.5">
+              <p className="text-[11px] text-slate-400">
+                開始・終了を設定すると差分から工数を自動計算します
+              </p>
+              {(startAt || endAt) && (
+                <button
+                  type="button"
+                  onClick={clearRange}
+                  className="text-[11px] text-slate-400 hover:text-red-500 px-1"
+                >
+                  クリア
+                </button>
+              )}
+            </div>
+            {timeError && (
+              <p className="text-[11px] text-red-500 mt-1">{timeError}</p>
+            )}
+          </div>
           <DueDateInput initialDate={initDue} onChange={setDueDate} />
-          <CategorySelect categories={categories} value={categoryId} onChange={setCategoryId} />
+          <CategorySelect
+            categories={categories}
+            value={categoryId}
+            onChange={setCategoryId}
+          />
         </div>
         <div className="flex gap-2.5 mt-6">
-          <button onClick={onClose} className="flex-1 py-3 rounded-xl bg-slate-100 text-slate-600 text-[13px] font-semibold hover:bg-slate-200 transition-colors">キャンセル</button>
-          <button onClick={handleSave} disabled={!title.trim()} className="flex-1 py-3 rounded-xl bg-indigo-600 text-white text-[13px] font-bold hover:bg-indigo-700 active:scale-[0.98] transition-all shadow-sm disabled:opacity-40 disabled:cursor-not-allowed">保存する</button>
+          <button
+            onClick={onClose}
+            className="flex-1 py-3 rounded-xl bg-slate-100 text-slate-600 text-[13px] font-semibold hover:bg-slate-200 transition-colors"
+          >
+            キャンセル
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={!title.trim()}
+            className="flex-1 py-3 rounded-xl bg-indigo-600 text-white text-[13px] font-bold hover:bg-indigo-700 active:scale-[0.98] transition-all shadow-sm disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            保存する
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/task-list/TaskListPage.tsx
+++ b/frontend/src/components/task-list/TaskListPage.tsx
@@ -11,6 +11,8 @@ import EditTaskModal, {
   DueDateInput,
   CategorySelect,
   toLocalDateStr,
+  isoToLocalDateTimeInput,
+  localDateTimeInputToIso,
 } from "./EditTaskModal";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
@@ -33,21 +35,76 @@ function AddTaskModal({
   const [durationMins, setDurationMins] = useState<number | null>(null);
   const [dueDate, setDueDate] = useState<Date | null>(null);
   const [categoryId, setCategoryId] = useState<number | null>(null);
+  const [startAt, setStartAt] = useState<string>("");
+  const [endAt, setEndAt] = useState<string>("");
+  const [timeError, setTimeError] = useState<string | null>(null);
+
+  function applyDurationFromRange(nextStart: string, nextEnd: string) {
+    if (!nextStart || !nextEnd) return;
+    const start = new Date(nextStart);
+    const end = new Date(nextEnd);
+    if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return;
+    const diffMins = Math.round((end.getTime() - start.getTime()) / 60000);
+    if (diffMins > 0) {
+      setDurationMins(diffMins);
+    }
+  }
+
+  function handleChangeStart(next: string) {
+    setStartAt(next);
+    setTimeError(null);
+    applyDurationFromRange(next, endAt);
+  }
+
+  function handleChangeEnd(next: string) {
+    setEndAt(next);
+    setTimeError(null);
+    applyDurationFromRange(startAt, next);
+  }
+
+  function clearRange() {
+    setStartAt("");
+    setEndAt("");
+    setTimeError(null);
+  }
 
   function handleAdd() {
     if (!title.trim()) return;
+    if ((startAt && !endAt) || (!startAt && endAt)) {
+      setTimeError("開始時間と終了時間はセットで入力してください");
+      return;
+    }
+
+    if (startAt && endAt) {
+      const start = new Date(startAt);
+      const end = new Date(endAt);
+      if (end.getTime() <= start.getTime()) {
+        setTimeError("終了時間は開始時間より後にしてください");
+        return;
+      }
+    }
+
+    const startIso = localDateTimeInputToIso(startAt);
+    const endIso = localDateTimeInputToIso(endAt);
+    const computedHours =
+      startAt && endAt
+        ? (new Date(endAt).getTime() - new Date(startAt).getTime()) / 3600000
+        : durationMins != null
+          ? durationMins / 60
+          : null;
+
     const newTask: Task = {
       id: Date.now(),
       title: title.trim(),
       description: description.trim() || null,
       priority: priority !== "" ? (parseInt(priority) as 1 | 2 | 3) : null,
       is_completed: false,
-      estimated_hours: durationMins != null ? durationMins / 60 : null,
+      estimated_hours: computedHours,
       ai_estimated_hours: null,
       ai_estimation_reason: null,
       due_date: dueDate ? toLocalDateStr(dueDate) : null,
-      start_time: null,
-      end_time: null,
+      start_time: startIso,
+      end_time: endIso,
       achievement_rate: null,
       category: null,
     };
@@ -108,6 +165,40 @@ function AddTaskModal({
             </select>
           </div>
           <DurationInput initialMins={null} onChange={setDurationMins} />
+          <div>
+            <label className={labelCls}>開始時間・終了時間</label>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <input
+                type="datetime-local"
+                value={startAt}
+                onChange={(e) => handleChangeStart(e.target.value)}
+                className={inputCls}
+              />
+              <input
+                type="datetime-local"
+                value={endAt}
+                onChange={(e) => handleChangeEnd(e.target.value)}
+                className={inputCls}
+              />
+            </div>
+            <div className="flex items-center justify-between mt-1.5">
+              <p className="text-[11px] text-slate-400">
+                開始・終了を設定すると差分から工数を自動計算します
+              </p>
+              {(startAt || endAt) && (
+                <button
+                  type="button"
+                  onClick={clearRange}
+                  className="text-[11px] text-slate-400 hover:text-red-500 px-1"
+                >
+                  クリア
+                </button>
+              )}
+            </div>
+            {timeError && (
+              <p className="text-[11px] text-red-500 mt-1">{timeError}</p>
+            )}
+          </div>
           <DueDateInput initialDate={null} onChange={setDueDate} />
           <CategorySelect
             categories={categories}

--- a/frontend/src/components/task-list/TaskListPage.tsx
+++ b/frontend/src/components/task-list/TaskListPage.tsx
@@ -5,7 +5,13 @@ import { useSearchParams, useRouter } from "next/navigation";
 import { Task } from "./types";
 import { sortTasks } from "./utils";
 import TaskListItem from "./TaskListItem";
-import EditTaskModal, { Category, DurationInput, DueDateInput, CategorySelect, toLocalDateStr } from "./EditTaskModal";
+import EditTaskModal, {
+  Category,
+  DurationInput,
+  DueDateInput,
+  CategorySelect,
+  toLocalDateStr,
+} from "./EditTaskModal";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
 
@@ -34,7 +40,7 @@ function AddTaskModal({
       id: Date.now(),
       title: title.trim(),
       description: description.trim() || null,
-      priority: priority !== "" ? parseInt(priority) as 1 | 2 | 3 : null,
+      priority: priority !== "" ? (parseInt(priority) as 1 | 2 | 3) : null,
       is_completed: false,
       estimated_hours: durationMins != null ? durationMins / 60 : null,
       ai_estimated_hours: null,
@@ -49,18 +55,26 @@ function AddTaskModal({
     onClose();
   }
 
-  const inputCls = "w-full border border-slate-200 rounded-xl px-3.5 py-2.5 text-[13px] text-slate-800 placeholder-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-300 transition";
+  const inputCls =
+    "w-full border border-slate-200 rounded-xl px-3.5 py-2.5 text-[13px] text-slate-800 placeholder-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-300 transition";
   const labelCls = "text-[11px] font-semibold text-slate-500 mb-1.5 block";
 
   return (
     <div className="fixed inset-0 z-[80] flex items-end sm:items-center justify-center pb-16 sm:pb-0 sm:p-4">
-      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
+      <div
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        onClick={onClose}
+      />
       <div className="relative bg-white w-full sm:max-w-md rounded-t-3xl sm:rounded-2xl shadow-2xl p-6 max-h-[90svh] overflow-y-auto">
         <div className="w-8 h-1 rounded-full bg-slate-200 mx-auto mb-5 sm:hidden" />
-        <h2 className="text-[16px] font-bold text-slate-900 mb-4">タスクを追加</h2>
+        <h2 className="text-[16px] font-bold text-slate-900 mb-4">
+          タスクを追加
+        </h2>
         <div className="flex flex-col gap-4">
           <div>
-            <label className={labelCls}>タスク名 <span className="text-red-400">*</span></label>
+            <label className={labelCls}>
+              タスク名 <span className="text-red-400">*</span>
+            </label>
             <input
               type="text"
               placeholder="タスク名を入力..."
@@ -95,11 +109,17 @@ function AddTaskModal({
           </div>
           <DurationInput initialMins={null} onChange={setDurationMins} />
           <DueDateInput initialDate={null} onChange={setDueDate} />
-          <CategorySelect categories={categories} value={categoryId} onChange={setCategoryId} />
+          <CategorySelect
+            categories={categories}
+            value={categoryId}
+            onChange={setCategoryId}
+          />
         </div>
         <div className="flex gap-2.5 mt-6">
-          <button onClick={onClose}
-            className="flex-1 py-3 rounded-xl bg-slate-100 text-slate-600 text-[13px] font-semibold hover:bg-slate-200 transition-colors">
+          <button
+            onClick={onClose}
+            className="flex-1 py-3 rounded-xl bg-slate-100 text-slate-600 text-[13px] font-semibold hover:bg-slate-200 transition-colors"
+          >
             キャンセル
           </button>
           <button
@@ -114,7 +134,6 @@ function AddTaskModal({
     </div>
   );
 }
-
 
 // ────────────────────────────────────────────
 // メインページ
@@ -141,6 +160,10 @@ export default function TaskListPage() {
 
   async function handleUpdateTask(updated: Task, categoryId: number | null) {
     try {
+      const original = tasks.find((t) => t.id === updated.id);
+      const hasRange = updated.start_time != null && updated.end_time != null;
+      const hasNoRange = updated.start_time == null && updated.end_time == null;
+
       const body: Record<string, unknown> = {
         title: updated.title,
         description: updated.description,
@@ -152,29 +175,57 @@ export default function TaskListPage() {
       } else {
         body.clear_priority = true;
       }
-      if (updated.estimated_hours != null) {
-        body.estimated_hours = updated.estimated_hours;
-      } else {
-        body.clear_estimated_hours = true;
+
+      if (hasRange) {
+        body.start_time = updated.start_time;
+        body.end_time = updated.end_time;
+      } else if (
+        hasNoRange &&
+        (original?.start_time != null || original?.end_time != null)
+      ) {
+        body.clear_start_time = true;
+        body.clear_end_time = true;
       }
+
+      // start/end が両方ある場合はバックエンドで工数を自動計算する
+      if (!hasRange) {
+        if (updated.estimated_hours != null) {
+          body.estimated_hours = updated.estimated_hours;
+        } else {
+          body.clear_estimated_hours = true;
+        }
+      }
+
       const res = await fetch(`${API_BASE}/tasks/${updated.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
-      if (!res.ok) { console.error("タスク更新エラー:", res.status, await res.text()); return; }
+      if (!res.ok) {
+        console.error("タスク更新エラー:", res.status, await res.text());
+        return;
+      }
       const saved: Task = await res.json();
-      setTasks((prev: Task[]) => prev.map((t) => (t.id === saved.id ? saved : t)));
-    } catch (e) { console.error("タスク更新エラー:", e); }
+      setTasks((prev: Task[]) =>
+        prev.map((t) => (t.id === saved.id ? saved : t)),
+      );
+    } catch (e) {
+      console.error("タスク更新エラー:", e);
+    }
   }
 
   async function handleDeleteTask(id: number) {
     try {
       const res = await fetch(`${API_BASE}/tasks/${id}`, { method: "DELETE" });
-      if (!res.ok) { console.error("タスク削除エラー:", res.status, await res.text()); return; }
+      if (!res.ok) {
+        console.error("タスク削除エラー:", res.status, await res.text());
+        return;
+      }
       setTasks((prev: Task[]) => prev.filter((t) => t.id !== id));
       setEditingTask(null);
-    } catch (e) { console.error("タスク削除エラー:", e); }
+    } catch (e) {
+      console.error("タスク削除エラー:", e);
+    }
   }
 
   async function handleToggleComplete(task: Task) {
@@ -184,10 +235,15 @@ export default function TaskListPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ is_completed: !task.is_completed }),
       });
-      if (!res.ok) { console.error("タスク更新エラー:", res.status, await res.text()); return; }
+      if (!res.ok) {
+        console.error("タスク更新エラー:", res.status, await res.text());
+        return;
+      }
       const saved: Task = await res.json();
       setTasks((prev) => prev.map((t) => (t.id === saved.id ? saved : t)));
-    } catch (e) { console.error("タスク更新エラー:", e); }
+    } catch (e) {
+      console.error("タスク更新エラー:", e);
+    }
   }
 
   async function handleAddTask(task: Task, categoryId: number | null) {
@@ -204,14 +260,19 @@ export default function TaskListPage() {
           category_id: categoryId,
         }),
       });
-      if (!res.ok) { console.error("タスク追加エラー:", res.status, await res.text()); return; }
+      if (!res.ok) {
+        console.error("タスク追加エラー:", res.status, await res.text());
+        return;
+      }
       const created: Task = await res.json();
       setTasks((prev: Task[]) => [created, ...prev]);
 
       // AI見積もりは非同期で実行されるため、完了後にタスクをリフェッチして反映
       setTimeout(async () => {
         try {
-          const updated = await fetch(`${API_BASE}/tasks`).then((r) => r.json());
+          const updated = await fetch(`${API_BASE}/tasks`).then((r) =>
+            r.json(),
+          );
           setTasks(updated);
         } catch (e) {
           console.error("AI見積もりリフェッチエラー:", e);
@@ -249,11 +310,14 @@ export default function TaskListPage() {
       !t.is_completed &&
       t.estimated_hours != null &&
       t.ai_estimated_hours != null &&
-      Math.abs(t.ai_estimated_hours - t.estimated_hours) > 0.5
+      Math.abs(t.ai_estimated_hours - t.estimated_hours) > 0.5,
   ).length;
 
   return (
-    <div className="flex flex-col bg-slate-50" style={{ height: "calc(100svh - var(--bottom-nav-height))" }}>
+    <div
+      className="flex flex-col bg-slate-50"
+      style={{ height: "calc(100svh - var(--bottom-nav-height))" }}
+    >
       {/* ── ヘッダー ── */}
       <div className="bg-white/90 backdrop-blur-sm flex-shrink-0 border-b border-slate-100">
         <div className="max-w-2xl mx-auto px-4 pt-5 pb-0">
@@ -269,7 +333,8 @@ export default function TaskListPage() {
               {/* サマリー */}
               <div className="flex items-center gap-2 mt-1">
                 <span className="text-[12px] text-slate-500">
-                  未完了 <strong className="text-slate-800">{activeCnt}</strong> 件
+                  未完了 <strong className="text-slate-800">{activeCnt}</strong>{" "}
+                  件
                 </span>
                 {alertCnt > 0 && (
                   <span className="text-[11px] font-bold text-amber-600 bg-amber-50 px-2 py-0.5 rounded-full">
@@ -325,34 +390,45 @@ export default function TaskListPage() {
 
       {/* ── タスクリスト ── */}
       <div className="flex-1 overflow-y-auto">
-      <div className="max-w-2xl mx-auto px-4 py-4">
-        {sorted.length === 0 ? (
-          <div className="text-center py-16">
-            <p className="text-[14px] text-slate-400 font-medium">
-              {filter === "done" ? "完了済みタスクはありません" : "タスクはありません"}
-            </p>
-            {filter === "active" && (
-              <button
-                onClick={() => setShowAdd(true)}
-                className="mt-3 text-[12px] text-indigo-600 font-semibold hover:underline"
-              >
-                最初のタスクを追加する →
-              </button>
-            )}
-          </div>
-        ) : (
-          <div className="flex flex-col gap-2.5">
-            {sorted.map((task) => (
-              <TaskListItem key={task.id} task={task} onEdit={() => setEditingTask(task)} onToggleComplete={() => handleToggleComplete(task)} />
-            ))}
-          </div>
-        )}
-      </div>
+        <div className="max-w-2xl mx-auto px-4 py-4">
+          {sorted.length === 0 ? (
+            <div className="text-center py-16">
+              <p className="text-[14px] text-slate-400 font-medium">
+                {filter === "done"
+                  ? "完了済みタスクはありません"
+                  : "タスクはありません"}
+              </p>
+              {filter === "active" && (
+                <button
+                  onClick={() => setShowAdd(true)}
+                  className="mt-3 text-[12px] text-indigo-600 font-semibold hover:underline"
+                >
+                  最初のタスクを追加する →
+                </button>
+              )}
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2.5">
+              {sorted.map((task) => (
+                <TaskListItem
+                  key={task.id}
+                  task={task}
+                  onEdit={() => setEditingTask(task)}
+                  onToggleComplete={() => handleToggleComplete(task)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
       {/* ── タスク追加モーダル ── */}
       {showAdd && (
-        <AddTaskModal onClose={() => setShowAdd(false)} onAdd={handleAddTask} categories={categories} />
+        <AddTaskModal
+          onClose={() => setShowAdd(false)}
+          onAdd={handleAddTask}
+          categories={categories}
+        />
       )}
 
       {/* ── タスク編集モーダル ── */}

--- a/frontend/src/components/time-blocking/TimeBlockingPage.tsx
+++ b/frontend/src/components/time-blocking/TimeBlockingPage.tsx
@@ -327,31 +327,32 @@ function TimeBlockingContent() {
 
   async function handleUpdateTask(updated: Task, categoryId: number | null) {
     try {
-      // タイムブロック済み & estimated_hours が変わった場合は end_time を再計算して PUT に含める
-      let newEndTime: string | undefined = undefined;
       const original = tasks.find((t) => t.id === updated.id);
-      if (
-        updated.start_time &&
-        updated.estimated_hours != null &&
-        original?.estimated_hours !== updated.estimated_hours
-      ) {
-        const startMs = new Date(updated.start_time).getTime();
-        const endDate = new Date(
-          startMs + updated.estimated_hours * 3600 * 1000,
-        );
-        newEndTime = endDate.toISOString().slice(0, 19) + "Z";
-      }
+      const hasRange = updated.start_time != null && updated.end_time != null;
+      const hasNoRange = updated.start_time == null && updated.end_time == null;
 
       const body: Record<string, unknown> = {
         title: updated.title,
         description: updated.description,
         priority: updated.priority,
-        estimated_hours: updated.estimated_hours,
         due_date: updated.due_date,
         category_id: categoryId,
       };
-      if (newEndTime !== undefined) {
-        body.end_time = newEndTime;
+
+      if (hasRange) {
+        body.start_time = updated.start_time;
+        body.end_time = updated.end_time;
+      } else if (
+        hasNoRange &&
+        (original?.start_time != null || original?.end_time != null)
+      ) {
+        body.clear_start_time = true;
+        body.clear_end_time = true;
+      }
+
+      // start/end が両方ある場合はバックエンドで工数を自動計算する
+      if (!hasRange) {
+        body.estimated_hours = updated.estimated_hours;
       }
 
       const res = await fetch(`${API_BASE}/tasks/${updated.id}`, {
@@ -361,13 +362,8 @@ function TimeBlockingContent() {
       });
       if (!res.ok) throw new Error(`status ${res.status}`);
       const saved: Task = await res.json();
-      // オプティミスティック更新: end_time も反映する
       setTasks((prev: Task[]) =>
-        prev.map((t) =>
-          t.id === saved.id
-            ? { ...saved, end_time: newEndTime ?? saved.end_time }
-            : t,
-        ),
+        prev.map((t) => (t.id === saved.id ? saved : t)),
       );
     } catch (e) {
       console.error("タスク更新エラー:", e);
@@ -538,7 +534,7 @@ function TimeBlockingContent() {
           showError("タスクを移動できませんでした。");
         });
     },
-    [selectedDate, tasks],
+    [dragInfoRef, lastDropXRef, selectedDate, tasks],
   );
 
   // ③ D&D: タイムライン上でドラッグオーバー中 → インジケーター更新


### PR DESCRIPTION
### 修正点
タスク編集UIに開始時間・終了時間を追加
開始/終了を両方入れたら差分で工数を自動計算
開始/終了は null クリア可能（削除可能）
更新API送信を開始/終了の設定・クリアに対応
バックエンドは開始/終了受け取り時に工数を自動計算
開始時間が null のタスクはタイムブロッキングに表示されない仕様で、削除時に非表示になる動線を維持

### 編集後写真
<img width="1676" height="898" alt="image" src="https://github.com/user-attachments/assets/4010bc76-80c5-4e99-a6fe-7ef6dc8f3840" />
<img width="1677" height="898" alt="image" src="https://github.com/user-attachments/assets/132d7a4f-c46b-4a35-bb85-d5cddbef1fe2" />
